### PR TITLE
Update siricontrol.py

### DIFF
--- a/siricontrol.py
+++ b/siricontrol.py
@@ -1,5 +1,5 @@
 import time
-import imaplib
+import imaplib2
 import email
 import os
 import pkgutil
@@ -28,7 +28,7 @@ class Control():
 
         try:
             self.last_checked = -1
-            self.mail = imaplib.IMAP4_SSL("imap.gmail.com", 993)
+            self.mail = imaplib2.IMAP4_SSL("imap.gmail.com", 993)
             self.mail.login(username, password)
             self.mail.list()
             self.mail.select("Notes")
@@ -42,7 +42,7 @@ class Control():
 
             self.load()
             self.handle()
-        except imaplib.IMAP4.error:
+        except imaplib2.IMAP4.error:
             print("Your username and password is incorrect")
             print("Or IMAP is not enabled.")
 
@@ -92,13 +92,14 @@ class Control():
     def handle(self):
         """Handle new commands
 
-        Poll continuously every second and check for new commands.
+        Idle until there is a server side update to email
         """
         print("Fetching commands...")
         print("\n")
 
         while True:
             try:
+                self.mail.idle()
                 command = self.fetch_command()
                 if not command:
                     raise ControlException("No command found.")
@@ -126,7 +127,6 @@ class Control():
                 print("Received an exception while running: {exc}".format(
                     **locals()))
                 print("Restarting...")
-            time.sleep(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I found I kept getting TIMEOUT and broken pipe errors after running for periods of more than a day, due to the constant polling of the email server in the previous version. The update to imaplib2 allows use of idle() so the script waits until there is email to process. Seems much more reliable and uses less CPU. Works fine now on an old/original raspi as well as more recent.